### PR TITLE
Hotfix for jetbrains theme selection conflicting with Oxocarbon theme selection.

### DIFF
--- a/src/main/kotlin/com/github/lynxie/oxocarbon/settings/theme/ThemeSettingsComponent.kt
+++ b/src/main/kotlin/com/github/lynxie/oxocarbon/settings/theme/ThemeSettingsComponent.kt
@@ -31,7 +31,8 @@ class ThemeSettingsComponent {
             .panel
     }
     
-    fun setDropdownItem(dropdownItem: Any?) {
+    fun setDropdownItem(dropdownItem: Any) {
+        ThemeSettings.instance.dropdownState = dropdownItem
         themeSelectionDropdown.selectedItem = dropdownItem
     }
 }

--- a/src/main/kotlin/com/github/lynxie/oxocarbon/settings/theme/ThemeSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/lynxie/oxocarbon/settings/theme/ThemeSettingsConfigurable.kt
@@ -30,7 +30,8 @@ class ThemeSettingsConfigurable : Configurable {
         if (themeSettingsState.dropdownState == "Oxocarbon Light") {
             SettingsNotifications.notifyLightVariantWarning(ProjectManager.getInstance().openProjects.first())
         }
-        
+
+        LafManager.getInstance().repaintUI()
         LafManager.getInstance().updateUI()
     }
 

--- a/src/main/kotlin/com/github/lynxie/oxocarbon/settings/theme/ThemeSettingsListener.kt
+++ b/src/main/kotlin/com/github/lynxie/oxocarbon/settings/theme/ThemeSettingsListener.kt
@@ -1,5 +1,6 @@
 package com.github.lynxie.oxocarbon.settings.theme
 
+import com.intellij.ide.actions.QuickChangeLookAndFeel
 import com.intellij.ide.ui.LafManager
 import com.intellij.ide.ui.LafManagerListener
 import com.intellij.openapi.editor.colors.EditorColorsManager
@@ -16,12 +17,10 @@ class ThemeSettingsListener : LafManagerListener {
         
         val selectedThemeName = themeSettingsState.dropdownState
         
-        if (selectedThemeName != currentlyActiveUiName) {
-            println("_@user_$selectedThemeName")
+        if (selectedThemeName != currentlyActiveUiName && selectedThemeName.toString().contains("Oxocarbon")) {
             val selectedLaf = LafManager.getInstance().installedLookAndFeels.first { it.name == selectedThemeName }
-            editorColorsManager.globalScheme = editorColorsManager.getScheme("_@user_$selectedThemeName")
-            LafManager.getInstance().currentLookAndFeel = selectedLaf
-            LafManager.getInstance().repaintUI()
+            
+            QuickChangeLookAndFeel.switchLafAndUpdateUI(lafManager, selectedLaf, false)
         }
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -49,15 +49,10 @@
                 serviceImplementation="com.github.lynxie.oxocarbon.settings.OxocarbonVersionSettings"
         />
 
-        <applicationConfigurable
-                parentId="appearance"
-                instance="com.github.lynxie.oxocarbon.settings.theme.ThemeSettingsConfigurable"
-                id="com.github.lynxie.oxocarbon.settings.theme.ThemeSettingsConfigurable"
-                displayName="Oxocarbon Settings"/>
+<!--        <applicationConfigurable-->
+<!--                parentId="appearance"-->
+<!--                instance="com.github.lynxie.oxocarbon.settings.theme.ThemeSettingsConfigurable"-->
+<!--                id="com.github.lynxie.oxocarbon.settings.theme.ThemeSettingsConfigurable"-->
+<!--                displayName="Oxocarbon Settings"/>-->
     </extensions>
-    
-    <applicationListeners>
-        <listener class="com.github.lynxie.oxocarbon.settings.theme.ThemeSettingsListener"
-                  topic="com.intellij.ide.ui.LafManagerListener"/>
-    </applicationListeners>
 </idea-plugin>


### PR DESCRIPTION
This hotfix is to temporarily address #9 

This is not a permanent fix, this only makes it so that the plugin is usable, until we can find a way to properly implement a fix with the conflicting settings.