### PR TITLE
Fixed notification not firing when Light Variant is selected.

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### 🪦 Removed
 
 ### 🐛 Fixed
+- Notification not displaying when the Light variant was selected.
+- A typo in the notification body. "my" -> "may"
 
 ## v1.1.1 - 2024-08-08
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ javaVersion = 17
 
 pluginGroup = com.github.lynxie
 pluginName = Oxocarbon
-pluginVersion = 1.2.3
+pluginVersion = 1.2.6
 platformVersion = 2023.1.5
 platformType = IC
 pluginSinceBuild = 231

--- a/src/main/kotlin/com/github/lynxie/oxocarbon/listeners/ThemeChangeListenerImpl.kt
+++ b/src/main/kotlin/com/github/lynxie/oxocarbon/listeners/ThemeChangeListenerImpl.kt
@@ -20,15 +20,14 @@ class ThemeChangeListenerImpl : LafManagerListener {
             if (settingsPanel != null) {
                 if (settingsPanel.themeSelectionDropdown.selectedItem != themeVariant) {
                     settingsPanel.setVariantDropdownItem(themeVariant)
-
-                    // Notify user if needed
-                    if (themeVariant.themeName == ThemeVariant.LIGHT.themeName) {
-                        val project = ProjectManager.getInstance().defaultProject
-                        SettingsNotifications.notifyLightVariantWarning(project)
-                    }
-                    ApplicationManager.getApplication().messageBus
                 }
             }
+        }
+
+        // Notify user if needed
+        if (selectedLafName == ThemeVariant.LIGHT.themeName) {
+            val project = ProjectManager.getInstance().defaultProject
+            SettingsNotifications.notifyLightVariantWarning(project)
         }
     }
 }

--- a/src/main/kotlin/com/github/lynxie/oxocarbon/notifications/SettingsNotifications.kt
+++ b/src/main/kotlin/com/github/lynxie/oxocarbon/notifications/SettingsNotifications.kt
@@ -23,7 +23,7 @@ class SettingsNotifications {
 
         @Language("HTML")
         private const val LIGHT_MODE_WARNING: String =
-            "<p>Oxocarbon Light is currently a work in progress, some things my not look correctly," +
+            "<p>Oxocarbon Light is currently a work in progress, some things may not look correctly," +
                     " or may not appear at all! If you notice anything that may seem off, please submit a ticket on GitHub!"
 
 


### PR DESCRIPTION
This PR address's Issue #14

The issue was that we were sending the notifications on the EDT thread which was most likely causing the notification to not fire.